### PR TITLE
Release `v0.1.1` with some internal improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "takecell"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 description = "A cell type which value can only be taken once"

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ impl<T> TakeOwnCell<T> {
     fn take(&self) -> Option<T> { ... }
 }
 ```
+
+To use this crate add the following to your `Cargo.toml`:
+
+```toml
+[dependencies] 
+kiam = "0.1"
+```

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ To use this crate add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies] 
-kiam = "0.1"
+takecell = "0.1"
 ```


### PR DESCRIPTION
- Use `swap` instead of `compare_exchange`
- Use weaker memory ordering
